### PR TITLE
Fix listener cleanup in Graph

### DIFF
--- a/src/core/graph.js
+++ b/src/core/graph.js
@@ -4,12 +4,14 @@ import { LiteGraphConverter } from "../utils/litegraph-converter.js";
 
 export class Graph extends LGraph {
   #uuid = null;
+  emitOnNodePropertyChangeBound = null;
 
   constructor(o) {
     super(o);
     this.eventEmitter = new EventEmitter();
     this.#uuid = null;
     this.isConfiguring = false;
+    this.emitOnNodePropertyChangeBound = this.emitOnNodePropertyChange.bind(this);
     this.updateGraphUuid();
   }
 
@@ -106,7 +108,7 @@ export class Graph extends LGraph {
       this.updateGraphUuid();
     }
 
-    node.on("propertyChanged", this.emitOnNodePropertyChange.bind(this));
+    node.on("propertyChanged", this.emitOnNodePropertyChangeBound);
     this.eventEmitter.emit("nodeAdded", this, node);
   }
 
@@ -114,7 +116,7 @@ export class Graph extends LGraph {
     if (!this.isConfiguring) {
       this.updateGraphUuid();
     }
-    node.off("propertyChanged", this.emitOnNodePropertyChange.bind(this));
+    node.off("propertyChanged", this.emitOnNodePropertyChangeBound);
     this.eventEmitter.emit("nodeRemoved", this, node);
   }
 


### PR DESCRIPTION
## Summary
- store the bound `emitOnNodePropertyChange` on the Graph instance
- use that stored function in `onNodeAdded` and `onNodeRemoved`

## Testing
- `node test-listener.js` *(with stub module)*

------
https://chatgpt.com/codex/tasks/task_e_6840e5e8999c83308efd830f7f02d6ea